### PR TITLE
Decl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ version: '1.3.14'
 kubernetes_files: './quobyte'
 registry:
     nodes:
-        - 207.154.211.166
-        - 207.154.211.247
-        - 207.154.215.157
+        - node01
+        - node02
+        - node3
 metadata:
     nodes:
-        - 207.154.211.166
-        - 207.154.211.247
-        - 207.154.215.157
+        - node01
+        - node02
+        - node03
 client:
     mount_opts: '' # example: '-o user_xattr'
 api:
@@ -65,6 +65,8 @@ default:
             memory: 1Gi
             cpu: 500m
 ```
+
+You can find some sample config files for the operator inside the <examples> folder.
 
 ### Deployment
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,17 +1,10 @@
 namespace: quobyte
 version: '1.3.15'
 kubernetes_files: './quobyte'
-# make this more declarative (additional)
 registry:
-    nodes:
-        - host1
-        - host2
-        - host3
+    nodes: 3
 metadata:
-    nodes:
-        - host1
-        - host2
-        - host3
+    nodes: 3
 client:
     mount_opts: '' # example: '-o user_xattr'
 api:

--- a/examples/minimal.config
+++ b/examples/minimal.config
@@ -1,0 +1,27 @@
+namespace: quobyte
+version: '1.3.15'
+kubernetes_files: './quobyte'
+registry:
+    nodes: 3 # currently not idempotent
+metadata:
+    nodes: 3
+client:
+    mount_opts: '' # example: '-o user_xattr'
+api:
+    resources:
+        limits:
+            memory: 1Gi
+            cpu: 500m
+        requests:
+            memory: 500Mi
+            cpu: 250m
+default:
+    nodes:
+        - all
+    resources:
+        limits:
+            memory: 2Gi
+            cpu: 1
+        requests:
+            memory: 1Gi
+            cpu: 500m

--- a/quobyte-k8s-deployer.py
+++ b/quobyte-k8s-deployer.py
@@ -182,8 +182,9 @@ class QuobyteDeployer:
 
     def get_unlabeled_nodes(self, service, count):
         labeled = self.get_labeled_nodes_for_service(service)
-        if len(labeled) == count:
+        if len(labeled) >= count:
             return labeled
+        # TODO if number is bigger we should resize
 
         all_nodes = self.get_node_name_list(self.cached_nodes)
 

--- a/quobyte-k8s-deployer.py
+++ b/quobyte-k8s-deployer.py
@@ -6,6 +6,7 @@ import yaml
 import time
 import argparse
 import json
+import random
 
 
 def set_mount_opts_in_spec(spec, opts):
@@ -93,6 +94,7 @@ class QuobyteDeployer:
         self.version = quobyte_config['version']
         self.namespace = quobyte_config['namespace']
         self.quobyte_config = quobyte_config
+        self.cached_nodes = get_all_nodes()
 
     def deploy(self):
         self.create_namespace()
@@ -166,8 +168,13 @@ class QuobyteDeployer:
             return self.get_nodes_for_quobyte_service('default')
 
         nodes = self.quobyte_config[service].get('nodes', [])
+        if isinstance(nodes, int):
+            # we could save the state into etcd with TPR
+            # check if value is < 1 ?
+            return random.sample(self.cached_nodes, nodes)
+
         if len(nodes) > 0 and nodes[0] == 'all':
-            return get_all_nodes()
+            return self.cached_nodes
         if len(nodes) > 0:
             return nodes
 

--- a/quobyte-k8s-deployer.py
+++ b/quobyte-k8s-deployer.py
@@ -171,6 +171,7 @@ class QuobyteDeployer:
         if isinstance(nodes, int):
             # we could save the state into etcd with TPR
             # check if value is < 1 ?
+            # TODO check how many nodes allready labeled!
             return random.sample(self.cached_nodes, nodes)
 
         if len(nodes) > 0 and nodes[0] == 'all':
@@ -327,10 +328,13 @@ class QuobyteDeployer:
         if name not in self.quobyte_config or self.quobyte_config[name] is None or 'disks' not in self.quobyte_config[name]:
             return
 
-        c = spec['spec']['template']['metadata']['annotations']['pod.beta.kubernetes.io/init-containers']
+        c = spec['spec']['template']['metadata']['annotations'][
+            'pod.beta.kubernetes.io/init-containers']
         init_containers = json.loads(c)
-        init_containers[0]['env'] = [{'name': 'DISKS', 'value': ','.join(self.quobyte_config[name]['disks'])}]
-        spec['spec']['template']['metadata']['annotations']['pod.beta.kubernetes.io/init-containers'] = json.dumps(init_containers)
+        init_containers[0]['env'] = [
+            {'name': 'DISKS', 'value': ','.join(self.quobyte_config[name]['disks'])}]
+        spec['spec']['template']['metadata']['annotations'][
+            'pod.beta.kubernetes.io/init-containers'] = json.dumps(init_containers)
 
     def set_version_in_spec(self, spec):
         kind = spec['kind']

--- a/quobyte/client-ds.yaml
+++ b/quobyte/client-ds.yaml
@@ -79,7 +79,6 @@ spec:
           preStop:
             exec:
               command: ["/bin/bash", "-xc", "umount -f ${QUOBYTE_MOUNT_POINT}"]
-      hostPID: true
       nodeSelector:
         quobyte_client: "true"
       volumes:

--- a/quobyte/client-ds.yaml
+++ b/quobyte/client-ds.yaml
@@ -30,7 +30,7 @@ spec:
             fi
             if cut -d" " -f2 /etc/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
               if [[ -z $OPTS ]]; then
-                 OPTS="-o remount"
+                OPTS="-o remount"
               else
                 OPTS="$OPTS,remount"
               fi
@@ -42,9 +42,6 @@ spec:
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
             ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
-        securityContext:
-          privileged: true
-        hostPID: true
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
@@ -81,6 +78,9 @@ spec:
           preStop:
             exec:
               command: ["/bin/bash", "-xc", "umount -f ${QUOBYTE_MOUNT_POINT}"]
+        securityContext:
+          privileged: true
+      hostPID: true
       nodeSelector:
         quobyte_client: "true"
       volumes:

--- a/quobyte/client-ds.yaml
+++ b/quobyte/client-ds.yaml
@@ -21,23 +21,22 @@ spec:
           - -xec
           - |
             ADDR=$(echo $(nslookup ${QUOBYTE_REGISTRY} | grep -A10 -m1 -e 'Name:' | grep Address | awk '{split($0,a,":"); print a[2]}'  | awk '{print $1":7861"}') | tr ' ' ,)
-            if [[ ! -f /rootfs/etc/fuse.conf ]]; then
+            if [[ ! -f /etcfs/fuse.conf ]]; then
               echo "Copy fuse config to host"
-              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /rootfs/etc/fuse.conf
+              { echo -e '# Copied from Quobyte Client Container\n'; cat /etc/fuse.conf; } > /etcfs/fuse.conf
             fi
-            if [[ $(grep "^[^#]" /rootfs/etc/fuse.conf  | grep -c "user_allow_other" /rootfs/etc/fuse.conf) -eq 0 ]]; then
-              echo "user_allow_other" >> /rootfs/etc/fuse.conf
+            if [[ $(grep "^[^#]" /etcfs/fuse.conf  | grep -c "user_allow_other" /etcfs/fuse.conf) -eq 0 ]]; then
+              echo "user_allow_other" >> /etcfs/fuse.conf
             fi
-            if cut -d" " -f2 /etc/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
+            if cut -d" " -f2 /etcfs/mtab | grep -q ${QUOBYTE_MOUNT_POINT}; then
               if [[ -z $OPTS ]]; then
-                OPTS="-o remount"
+                 OPTS="-o remount"
               else
                 OPTS="$OPTS,remount"
               fi
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
             fi
-             # TODO generate UUID and use it
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
@@ -72,8 +71,8 @@ spec:
         volumeMounts:
           - name: k8s-plugin-dir
             mountPath: /var/lib/kubelet/plugins
-          - name: rootfs
-            mountPath: /rootfs
+          - name: etcfs
+            mountPath: /etcfs
         lifecycle:
           preStop:
             exec:
@@ -87,6 +86,6 @@ spec:
       - name: k8s-plugin-dir
         hostPath:
           path: /var/lib/kubelet/plugins
-      - name: rootfs
+      - name: etcfs
         hostPath:
-          path: /
+          path: /etc

--- a/quobyte/client-ds.yaml
+++ b/quobyte/client-ds.yaml
@@ -37,12 +37,14 @@ spec:
             else
               mkdir -p ${QUOBYTE_MOUNT_POINT}
             fi
+             # TODO generate UUID and use it
             /bin/nsenter -t 1 --wd=. -m -- \
               lib/ld-linux-x86-64.so.2 \
               --library-path ./lib \
             ./bin/mount.quobyte --hostname ${NODENAME} --allow-usermapping-in-volumename -f -d ${QUOBYTE_CLIENT_LOG_LEVEL} ${OPTS} ${ADDR}/ ${QUOBYTE_MOUNT_POINT}
         securityContext:
           privileged: true
+        hostPID: true
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO

--- a/quobyte/data-ds.yaml
+++ b/quobyte/data-ds.yaml
@@ -9,17 +9,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/path: '/prometheus'
         prometheus.io/port: '7873'
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "init-devices",
-                "image": "johscheuer/device_formatter:0.1",
-                "imagePullPolicy": "Always",
-                "securityContext": {
-                  "privileged": true
-                },
-                "hostPID": true
-            }
-        ]'
       labels:
         role: data
         version: VERSION
@@ -28,7 +17,9 @@ spec:
       - name: quobyte-metadata
         image: quay.io/quobyte/quobyte-server:VERSION
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
         env:
           - name: QUOBYTE_SERVICE
             value: data

--- a/quobyte/data-ds.yaml
+++ b/quobyte/data-ds.yaml
@@ -19,7 +19,7 @@ spec:
         securityContext:
           capabilities:
             add:
-              - SYS_ADMIN
+              - SYS_RESOURCE
         env:
           - name: QUOBYTE_SERVICE
             value: data
@@ -29,11 +29,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+        hostname:
+          valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         command:
           - /bin/bash
           - -xec
           - |
-            hostname $NODENAME
             sed "s/.*MIN_MEM_DATA=.*/MIN_MEM_DATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_DATA=.*/MAX_MEM_DATA=${MAX_MEM}/" -i /etc/default/quobyte
 

--- a/quobyte/data-ds.yaml
+++ b/quobyte/data-ds.yaml
@@ -24,15 +24,7 @@ spec:
           - name: QUOBYTE_SERVICE
             value: data
           - name: QUOBYTE_REGISTRY
-            value: _quobyte._tcp.registry
-          - name: NODENAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
-        hostname:
-          valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+            value: registry
         command:
           - /bin/bash
           - -xec

--- a/quobyte/metadata-ds.yaml
+++ b/quobyte/metadata-ds.yaml
@@ -9,17 +9,6 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/path: '/prometheus'
         prometheus.io/port: '7872'
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "init-devices",
-                "image": "johscheuer/device_formatter:0.1",
-                "imagePullPolicy": "Always",
-                "securityContext": {
-                  "privileged": true
-                },
-                "hostPID": true
-            }
-        ]'
       labels:
         role: metadata
         version: VERSION
@@ -28,7 +17,9 @@ spec:
       - name: quobyte-metadata
         image: quay.io/quobyte/quobyte-server:VERSION
         securityContext:
-          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
         env:
           - name: QUOBYTE_SERVICE
             value: metadata

--- a/quobyte/metadata-ds.yaml
+++ b/quobyte/metadata-ds.yaml
@@ -24,7 +24,7 @@ spec:
           - name: QUOBYTE_SERVICE
             value: metadata
           - name: QUOBYTE_REGISTRY
-            value: _quobyte._tcp.registry
+            value: registry
         command:
           - /bin/bash
           - -xec

--- a/quobyte/metadata-ds.yaml
+++ b/quobyte/metadata-ds.yaml
@@ -19,21 +19,16 @@ spec:
         securityContext:
           capabilities:
             add:
-              - SYS_ADMIN
+              - SYS_RESOURCE
         env:
           - name: QUOBYTE_SERVICE
             value: metadata
           - name: QUOBYTE_REGISTRY
             value: _quobyte._tcp.registry
-          - name: NODENAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
         command:
           - /bin/bash
           - -xec
           - |
-            hostname $NODENAME
             sed "s/.*MIN_MEM_METADATA=.*/MIN_MEM_METADATA=${MIN_MEM}/" -i /etc/default/quobyte
             sed "s/.*MAX_MEM_METADATA=.*/MAX_MEM_METADATA=${MAX_MEM}/" -i /etc/default/quobyte
             if [ ! "$(ls -A /devices)" ] && [ ! -f /devices/QUOBYTE_DEV_SETUP ]; then

--- a/quobyte/registry-ds.yaml
+++ b/quobyte/registry-ds.yaml
@@ -15,16 +15,12 @@ spec:
           securityContext:
             capabilities:
               add:
-                - SYS_ADMIN
+                - SYS_RESOURCE
           env:
             - name: QUOBYTE_SERVICE
               value: registry
             - name: QUOBYTE_REGISTRY
               value: _quobyte._tcp.registry
-            - name: NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: QUOBYTE_EXTRA_SERVICE_CONFIG
               value: >
                 constants.automation.manage_registry_replicas=true
@@ -45,7 +41,6 @@ spec:
             - /bin/bash
             - -xec
             - |
-              hostname $NODENAME
               sed "s/.*MIN_MEM_REGISTRY=.*/MIN_MEM_REGISTRY=${MIN_MEM}/" -i /etc/default/quobyte
               sed "s/.*MAX_MEM_REGISTRY=.*/MAX_MEM_REGISTRY=${MAX_MEM}/" -i /etc/default/quobyte
               # TODO if directory is empty skip -> /dev1 needed?
@@ -62,11 +57,11 @@ spec:
                 fi
               fi
 
-              if [ ! -f /devices/UUID ]; then
-                echo uuid=$(uuidgen) >> /devices/UUID
+              if [ ! -f /devices/dev1/UUID ]; then
+                echo uuid=$(uuidgen) >> /devices/dev1/UUID
               fi
 
-              cat /devices/UUID >> /etc/quobyte/$QUOBYTE_SERVICE.cfg
+              cat /devices/dev1/UUID >> /etc/quobyte/$QUOBYTE_SERVICE.cfg
 
               exec /bin/bash -x /opt/main.sh
           lifecycle:

--- a/quobyte/registry-ds.yaml
+++ b/quobyte/registry-ds.yaml
@@ -8,24 +8,14 @@ spec:
       labels:
         role: registry
         version: VERSION
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "init-devices",
-                "image": "johscheuer/device_formatter:0.1",
-                "imagePullPolicy": "Always",
-                "securityContext": {
-                  "privileged": true
-                },
-                "hostPID": true
-            }
-        ]'
     spec:
       containers:
         - name: quobyte-registry
           image: quay.io/quobyte/quobyte-server:VERSION
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN
           env:
             - name: QUOBYTE_SERVICE
               value: registry

--- a/quobyte/registry-ds.yaml
+++ b/quobyte/registry-ds.yaml
@@ -20,7 +20,7 @@ spec:
             - name: QUOBYTE_SERVICE
               value: registry
             - name: QUOBYTE_REGISTRY
-              value: _quobyte._tcp.registry
+              value: registry
             - name: QUOBYTE_EXTRA_SERVICE_CONFIG
               value: >
                 constants.automation.manage_registry_replicas=true


### PR DESCRIPTION
There are some improvements in this commit:

- `Server` components don't need `privileged` anymore
- More declarative Config like `create 5 metadata service`, we often don't care on which machines they actually run
- Remove the init container